### PR TITLE
유니언 타입 체크 해결 방안

### DIFF
--- a/UML.mdj
+++ b/UML.mdj
@@ -2016,7 +2016,7 @@
 									"font": "Arial;13;0",
 									"left": 296,
 									"top": 288,
-									"width": 90.919921875,
+									"width": 90.18994140625,
 									"height": 25,
 									"stereotypeLabel": {
 										"$ref": "AAAAAAFwL4aaBUlxV+c="
@@ -3928,7 +3928,7 @@
 											"font": "Arial;13;1",
 											"left": 13,
 											"top": 23,
-											"width": 384.01416015625,
+											"width": 400.36572265625,
 											"height": 13,
 											"text": "Profile"
 										},
@@ -3955,7 +3955,7 @@
 											"font": "Arial;13;0",
 											"left": 13,
 											"top": 38,
-											"width": 384.01416015625,
+											"width": 400.36572265625,
 											"height": 13,
 											"text": "{verbose_name_plural=\"사용자\", __str__=\"name\"}",
 											"horizontalAlignment": 1
@@ -3964,7 +3964,7 @@
 									"font": "Arial;13;0",
 									"left": 8,
 									"top": 16,
-									"width": 394.01416015625,
+									"width": 410.36572265625,
 									"height": 40,
 									"stereotypeLabel": {
 										"$ref": "AAAAAAFq+CS8uBvEorQ="
@@ -4001,7 +4001,7 @@
 											"font": "Arial;13;0",
 											"left": 13,
 											"top": 61,
-											"width": 384.01416015625,
+											"width": 400.36572265625,
 											"height": 13,
 											"text": "+user: onetoone {to=\"auth.User\", on_delete=\"models.CASCADE\"}",
 											"horizontalAlignment": 0
@@ -4018,7 +4018,7 @@
 											"font": "Arial;13;0",
 											"left": 13,
 											"top": 76,
-											"width": 384.01416015625,
+											"width": 400.36572265625,
 											"height": 13,
 											"text": "+name: string {max_length=100}",
 											"horizontalAlignment": 0
@@ -4035,7 +4035,7 @@
 											"font": "Arial;13;0",
 											"left": 13,
 											"top": 91,
-											"width": 384.01416015625,
+											"width": 400.36572265625,
 											"height": 13,
 											"text": "+profile_img: string {max_length=200, null=true, blank=true}",
 											"horizontalAlignment": 0
@@ -4044,7 +4044,7 @@
 									"font": "Arial;13;0",
 									"left": 8,
 									"top": 56,
-									"width": 394.01416015625,
+									"width": 410.36572265625,
 									"height": 53
 								},
 								{
@@ -4059,7 +4059,7 @@
 									"font": "Arial;13;0",
 									"left": 8,
 									"top": 109,
-									"width": 394.01416015625,
+									"width": 410.36572265625,
 									"height": 10
 								},
 								{
@@ -4099,7 +4099,7 @@
 							"containerChangeable": true,
 							"left": 8,
 							"top": 16,
-							"width": 394.01416015625,
+							"width": 410.36572265625,
 							"height": 118,
 							"nameCompartment": {
 								"$ref": "AAAAAAFq+CS8uBvDhUA="
@@ -8971,7 +8971,7 @@
 										"$ref": "AAAAAAFwRhJX4r+2JEg="
 									},
 									"font": "Arial;13;0",
-									"left": 191,
+									"left": 195,
 									"top": 161,
 									"width": 46.76953125,
 									"height": 13,
@@ -8994,8 +8994,8 @@
 									},
 									"visible": null,
 									"font": "Arial;13;0",
-									"left": 213,
-									"top": 178,
+									"left": 217,
+									"top": 177,
 									"height": 13,
 									"alpha": 1.5707963267948966,
 									"distance": 30,
@@ -9014,7 +9014,7 @@
 										"$ref": "AAAAAAFwRhJX4r+2JEg="
 									},
 									"font": "Arial;13;0",
-									"left": 32,
+									"left": 36,
 									"top": 175,
 									"width": 380.50390625,
 									"height": 13,
@@ -9037,8 +9037,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 234,
-									"top": 190,
+									"left": 237,
+									"top": 189,
 									"height": 13,
 									"alpha": 0.5235987755982988,
 									"distance": 30,
@@ -9058,8 +9058,8 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 221,
-									"top": 192,
+									"left": 224,
+									"top": 191,
 									"height": 13,
 									"alpha": 0.7853981633974483,
 									"distance": 40,
@@ -9078,7 +9078,7 @@
 										"$ref": "AAAAAAFwRhJX4r+33q8="
 									},
 									"font": "Arial;13;0",
-									"left": 252,
+									"left": 255,
 									"top": 184,
 									"width": 19.5126953125,
 									"height": 13,
@@ -9101,7 +9101,7 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 199,
+									"left": 203,
 									"top": 157,
 									"width": 46.76953125,
 									"height": 13,
@@ -9123,7 +9123,7 @@
 									},
 									"visible": false,
 									"font": "Arial;13;0",
-									"left": 121,
+									"left": 125,
 									"top": 183,
 									"width": 190.98193359375,
 									"height": 13,
@@ -9143,9 +9143,9 @@
 										"$ref": "AAAAAAFwRhJX4r+4vD8="
 									},
 									"font": "Arial;13;0",
-									"left": 243,
-									"top": 143,
-									"width": 7.22998046875,
+									"left": 241,
+									"top": 144,
+									"width": 19.5126953125,
 									"height": 13,
 									"alpha": 0.5235987755982988,
 									"distance": 25,
@@ -9195,7 +9195,7 @@
 								"$ref": "AAAAAAFwRhIc1r6b1DI="
 							},
 							"lineStyle": 1,
-							"points": "258:215;227:134",
+							"points": "260:215;232:134",
 							"showVisibility": true,
 							"nameLabel": {
 								"$ref": "AAAAAAFwRhJX47+7ANI="

--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,16 @@
 from django.db import models
 
+class Media(models.Model):
+    class Meta:
+        pass
+
+    file = models.FileField(upload_to='%Y/%m/%d')
+    boarditem = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='BoardItem')
+    shopproduct = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='ShopProduct')
+    profile = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='Profile')
+    extra = models.CharField(max_length=100, null=True, blank=True)
+
+
 class Device(models.Model):
     class Meta:
         pass
@@ -15,23 +26,20 @@ class Profile(models.Model):
         verbose_name_plural='사용자'
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     user = models.OneToOneField(to='auth.User', on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     profile_img = models.CharField(max_length=200, null=True, blank=True)
 
 
-class Media(models.Model):
+class MonitorCpu(models.Model):
     class Meta:
         pass
 
-    file = models.FileField(upload_to='%Y/%m/%d')
-    boarditem = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='BoardItem')
-    shopproduct = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='ShopProduct')
-    profile = models.ForeignKey(on_delete=models.CASCADE, null=True, blank=True, to='Profile')
-    extra = models.CharField(max_length=100, null=True, blank=True)
+    name = models.CharField(max_length=100)
 
+    server = models.ForeignKey('MonitorServer', on_delete=models.CASCADE)
 
 class MonitorUsage(models.Model):
     class Meta:
@@ -42,14 +50,6 @@ class MonitorUsage(models.Model):
 
     cpu = models.ForeignKey('MonitorCpu', on_delete=models.CASCADE, null=True, blank=True)
     memory = models.ForeignKey('MonitorMemory', on_delete=models.CASCADE, null=True, blank=True)
-
-class MonitorCpu(models.Model):
-    class Meta:
-        pass
-
-    name = models.CharField(max_length=100)
-
-    server = models.ForeignKey('MonitorServer', on_delete=models.CASCADE)
 
 class MonitorMemory(models.Model):
     class Meta:
@@ -67,12 +67,40 @@ class MonitorServer(models.Model):
     keep_day = models.IntegerField(default=7)
 
 
+class ChatRoom(models.Model):
+    class Meta:
+        pass
+
+    user = models.ManyToManyField(to='Profile')
+
+
+class ChatMessage(models.Model):
+    class Meta:
+        pass
+
+    sender = models.ForeignKey(to='Profile', on_delete=models.SET_NULL, null=True, blank=True)
+    content = models.TextField(null=True, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+
+    room = models.ForeignKey('ChatRoom', on_delete=models.CASCADE)
+
+class BoardComment(models.Model):
+    class Meta:
+        verbose_name_plural='게시판 댓글'
+
+    content = models.TextField(null=True)
+    created = models.DateTimeField(auto_now=True)
+    author = models.ForeignKey(on_delete=models.CASCADE, to='Profile')
+
+    item = models.ForeignKey('BoardItem', on_delete=models.CASCADE)
+    parent = models.ForeignKey('BoardComment', null=True, on_delete=models.CASCADE)
+
 class BoardGroup(models.Model):
     class Meta:
         verbose_name_plural='게시판 그룹'
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     name = models.CharField(max_length=100)
     readonly = models.BooleanField(default=False)
@@ -91,44 +119,6 @@ class BoardItem(models.Model):
 
     group = models.ForeignKey('BoardGroup', on_delete=models.CASCADE)
 
-class BoardComment(models.Model):
-    class Meta:
-        verbose_name_plural='게시판 댓글'
-
-    content = models.TextField(null=True)
-    created = models.DateTimeField(auto_now=True)
-    author = models.ForeignKey(on_delete=models.CASCADE, to='Profile')
-
-    item = models.ForeignKey('BoardItem', on_delete=models.CASCADE)
-    parent = models.ForeignKey('BoardComment', null=True, on_delete=models.CASCADE)
-
-class TaskClient(models.Model):
-    class Meta:
-        pass
-
-    channel_name = models.CharField(max_length=100)
-
-    work = models.ForeignKey('TaskWork', on_delete=models.CASCADE)
-
-class TaskWork(models.Model):
-    class Meta:
-        pass
-
-    owner = models.ForeignKey(to='Profile', on_delete=models.CASCADE)
-    progress = models.IntegerField(default=0)
-    status = models.CharField(max_length=100)
-    body = models.TextField(null=True, blank=True)
-
-
-class ShopCart(models.Model):
-    class Meta:
-        verbose_name_plural='상점 장바구니'
-
-    isOpen = models.BooleanField(default=True)
-    profile = models.ForeignKey(on_delete=models.CASCADE, to='Profile')
-
-    product = models.ManyToManyField('ShopProduct', blank=True)
-
 class ShopBilling(models.Model):
     class Meta:
         verbose_name_plural='상점 구독내역'
@@ -143,15 +133,17 @@ class ShopBilling(models.Model):
     subscription = models.ForeignKey('ShopSubscription', on_delete=models.SET_NULL, null=True, blank=True)
     card = models.ForeignKey('ShopCard', on_delete=models.SET_NULL, null=True, blank=True)
 
-class ShopPayment(models.Model):
+class ShopCard(models.Model):
     class Meta:
-        verbose_name_plural='상점 결재내역'
+        verbose_name_plural='상점 구독카드'
 
-    imp_uid = models.CharField(max_length=100)
-    status = models.CharField(max_length=100)
-    vbank = models.CharField(max_length=100, null=True, blank=True)
+    name = models.CharField(max_length=100)
+    customer_uid = models.CharField(max_length=100)
+    profile = models.ForeignKey(to='Profile', on_delete=models.CASCADE)
+    buyer_name = models.CharField(max_length=100)
+    buyer_email = models.CharField(max_length=100)
+    buyer_tel = models.CharField(max_length=100)
 
-    cart = models.OneToOneField('ShopCart', on_delete=models.SET_NULL, null=True, blank=True)
 
 class ShopSubscription(models.Model):
     class Meta:
@@ -172,32 +164,40 @@ class ShopProduct(models.Model):
     content = models.TextField(null=True, blank=True)
 
 
-class ShopCard(models.Model):
+class ShopPayment(models.Model):
     class Meta:
-        verbose_name_plural='상점 구독카드'
+        verbose_name_plural='상점 결재내역'
 
-    name = models.CharField(max_length=100)
-    customer_uid = models.CharField(max_length=100)
-    profile = models.ForeignKey(to='Profile', on_delete=models.CASCADE)
-    buyer_name = models.CharField(max_length=100)
-    buyer_email = models.CharField(max_length=100)
-    buyer_tel = models.CharField(max_length=100)
+    imp_uid = models.CharField(max_length=100)
+    status = models.CharField(max_length=100)
+    vbank = models.CharField(max_length=100, null=True, blank=True)
 
+    cart = models.OneToOneField('ShopCart', on_delete=models.SET_NULL, null=True, blank=True)
 
-class ChatRoom(models.Model):
+class ShopCart(models.Model):
+    class Meta:
+        verbose_name_plural='상점 장바구니'
+
+    isOpen = models.BooleanField(default=True)
+    profile = models.ForeignKey(on_delete=models.CASCADE, to='Profile')
+
+    product = models.ManyToManyField('ShopProduct', blank=True)
+
+class TaskWork(models.Model):
     class Meta:
         pass
 
-    user = models.ManyToManyField(to='Profile')
+    owner = models.ForeignKey(to='Profile', on_delete=models.CASCADE)
+    progress = models.IntegerField(default=0)
+    status = models.CharField(max_length=100)
+    body = models.TextField(null=True, blank=True)
 
 
-class ChatMessage(models.Model):
+class TaskClient(models.Model):
     class Meta:
         pass
 
-    sender = models.ForeignKey(to='Profile', on_delete=models.SET_NULL, null=True, blank=True)
-    content = models.TextField(null=True, blank=True)
-    created = models.DateTimeField(auto_now_add=True)
+    channel_name = models.CharField(max_length=100)
 
-    room = models.ForeignKey('ChatRoom', on_delete=models.CASCADE)
+    work = models.ForeignKey('TaskWork', on_delete=models.CASCADE)
 

--- a/react/src/app/core/Api.ts
+++ b/react/src/app/core/Api.ts
@@ -124,7 +124,7 @@ export class Api {
             }
         }).then(res => res.data)
     }
-    static async expand(arr: Array<any>, key: string, url: string, mtm: boolean = false) {
+    static async expand<T>(arr: Array<any>, key: string, url: string, mtm: boolean = false): Promise<T[]> {
         let ids
         if (mtm) ids = U.union(arr.filter(item => item[key]).map((item: any) => item[key]))
         else ids = U.union([arr.filter(item => item[key]).map((item: any) => item[key])])
@@ -135,6 +135,7 @@ export class Api {
             if (mtm) arr.forEach((item: any) => item[key] = item[key].map((id: number) => res.filter(r => r.id === id)[0]))
             else arr.forEach((item: any) => item[key] = res.filter(r => r.id === item[key])[0])
         }
+        return Promise.resolve(arr)
     }
     static signIn(jwt_token: string, user_profile: ApiType.Profile | undefined) {
         if (typeof localStorage !== 'undefined') {

--- a/react/src/auth/SignIn.tsx
+++ b/react/src/auth/SignIn.tsx
@@ -11,9 +11,9 @@ import SocialLogin from 'auth/SocialLogin';
 import { translation } from 'component/I18next';
 
 interface Props {
-  auth:AuthState
-  AuthAction: typeof AuthAction
-  history: History
+  auth:AuthState;
+  AuthAction: typeof AuthAction;
+  history: History;
 }
 
 class SignIn extends React.Component<Props> {
@@ -37,12 +37,6 @@ class SignIn extends React.Component<Props> {
       password:false,
       activate:false
     }
-  }
-  async componentDidMount(){ // 테스트 코드
-    const ttt = await Api.list<ApiType.Device<number>[]>('/api-device/',{});
-    console.log(typeof ttt[0].profile) // (property) profile: number
-    const aaa = await Api.expand<ApiType.Device<ApiType.Profile>>(ttt, 'profile', '/api-profile/')
-    console.log(typeof aaa[0].profile) // (property) profile: ApiType.Profile
   }
 
   async submit(e:React.FormEvent<HTMLFormElement>) {

--- a/react/src/auth/SignIn.tsx
+++ b/react/src/auth/SignIn.tsx
@@ -38,6 +38,12 @@ class SignIn extends React.Component<Props> {
       activate:false
     }
   }
+  async componentDidMount(){ // 테스트 코드
+    const ttt = await Api.list<ApiType.Device<number>[]>('/api-device/',{});
+    console.log(typeof ttt[0].profile) // (property) profile: number
+    const aaa = await Api.expand<ApiType.Device<ApiType.Profile>>(ttt, 'profile', '/api-profile/')
+    console.log(typeof aaa[0].profile) // (property) profile: ApiType.Profile
+  }
 
   async submit(e:React.FormEvent<HTMLFormElement>) {
     e.stopPropagation()

--- a/react/src/board/Board.action.tsx
+++ b/react/src/board/Board.action.tsx
@@ -34,7 +34,7 @@ export const BoardAction = {
             group:group.id,
             valid:1
         })
-        await Api.expand(res.items, 'author', '/api-profile/')
+        const www = await Api.expand<ApiType.BoardItem<ApiType.Profile>>(res.items, 'author', '/api-profile/')
         return Promise.resolve({
             totalPage:res.total_page,
             currentPage:page,

--- a/react/src/dashboard/Dashboard.action.tsx
+++ b/react/src/dashboard/Dashboard.action.tsx
@@ -4,12 +4,12 @@ import { Api } from "app/core/Api";
 import { U } from "app/core/U";
 
 export type DashboardState = {
-    shopProducts:ApiType.ShopProduct[],
-    shopProduct?:ApiType.ShopProduct
-    shopCurrentPage:number
-    shopTotalPage:number
-    shopSubscriptions:ApiType.ShopSubscription[]
-    chatRooms:ApiType.ChatRoom[]
+    shopProducts:ApiType.ShopProduct[];
+    shopProduct?:ApiType.ShopProduct;
+    shopCurrentPage:number;
+    shopTotalPage:number;
+    shopSubscriptions:ApiType.ShopSubscription[];
+    chatRooms:ApiType.ChatRoom[];
 }
 
 const initState:DashboardState = {
@@ -49,7 +49,7 @@ export const DashboardAction = {
         const rooms = await Api.list<ApiType.ChatRoom[]>('/api-chat/room/',{
             'user':profile.id,
         })
-        await Api.expand(rooms, 'user', '/api-profile/', true)
+        await Api.expand<ApiType.ChatRoom<ApiType.Profile>>(rooms, 'user', '/api-profile/', true)
         return Promise.resolve({chatRooms:rooms})
     },
     exitChatRoom:async(profile:ApiType.Profile, room:ApiType.ChatRoom)=> {
@@ -58,7 +58,7 @@ export const DashboardAction = {
             await Api.delete('/api-chat/room/',chatRoom.id)
         } else {
             await Api.update('/api-chat/room/',chatRoom.id,{
-                user:(chatRoom.user as number[]).filter(user=> user !== profile.id)
+                user:chatRoom.user.filter(user=> user !== profile.id)
             })
         }
         return DashboardAction.loadChatRoom(profile)

--- a/react/src/mypage/Mypage.action.tsx
+++ b/react/src/mypage/Mypage.action.tsx
@@ -186,8 +186,6 @@ export const MypageAction = {
         const subs = await Api.list<ApiType.ShopSubscription[]>('/api-shop/subscription/', {
             'pk__in[]':res.items.map(item=>item.subscription)
         })
-        console.log(res)
-        console.log(subs)
         res.items.forEach(billing=> {
             billing.subscription = subs.filter(sub=>billing.subscription.id === sub.id)[0]
         })

--- a/react/src/mypage/Mypage.action.tsx
+++ b/react/src/mypage/Mypage.action.tsx
@@ -5,14 +5,14 @@ import { U } from "app/core/U";
 import moment from 'moment';
 
 export type MypageState = {
-    carts:ApiType.ShopCart[]
-    cartCurrentPage:number
-    cartTotalPage:number
-    products:ApiType.ShopProduct[]
-    payments:ApiType.ShopPayment[]
-    subscription?:ApiType.ShopSubscription
-    cards:ApiType.ShopCard[]
-    billings:ApiType.ShopBilling[]
+    carts:ApiType.ShopCart[];
+    cartCurrentPage:number;
+    cartTotalPage:number;
+    products:ApiType.ShopProduct[];
+    payments:ApiType.ShopPayment[];
+    subscription?:ApiType.ShopSubscription;
+    cards:ApiType.ShopCard[];
+    billings:ApiType.ShopBilling[];
 }
 
 const initState:MypageState = {
@@ -38,7 +38,7 @@ export const MypageAction = {
             valid:1
         })
         res.items.forEach(item=>{
-            item.product = U.union((item.product as number[]).map(id=> products.filter(p=> p.id === id)))
+            item.product = U.union(item.product.map(id=> products.filter(p=> p.id === id)))
         })
         const payments = await Api.list<ApiType.ShopPayment[]>('/api-shop/payment/', {
             'cart__in[]':res.items.map(item=>item.id)
@@ -54,7 +54,8 @@ export const MypageAction = {
         const res = await Api.list<ApiType.ShopCart[]>('/api-shop/cart/', {
             isOpen:1
         })
-        let cart;
+
+        let cart:ApiType.ShopCart;
         if (res.length === 0) {
             cart = await Api.create<ApiType.ShopCart>('/api-shop/cart/',{
                 isOpen:1,
@@ -63,14 +64,16 @@ export const MypageAction = {
         } else {
             cart = res[0];
         }
+        
         await Api.patch<ApiType.ShopCart>('/api-shop/cart/', cart.id, {
-            product:(cart.product as number[]).concat([product.id])
+            product:cart.product.concat([product.id])
         })
+        
         return Promise.resolve({})
     },
-    removeShopCart:async(cart:ApiType.ShopCart, product:ApiType.ShopProduct) => {
+    removeShopCart:async(cart:ApiType.ShopCart<number,ApiType.ShopProduct>, product:ApiType.ShopProduct) => {
         await Api.patch<ApiType.ShopCart>('/api-shop/cart/', cart.id, {
-            product:    (cart.product as ApiType.ShopProduct[])
+            product:    cart.product
                 .filter(item=> item.id !== product.id)
                 .map(item=>item.id)
         })
@@ -98,7 +101,7 @@ export const MypageAction = {
             type:type,
             id:id
         })
-        let cart!:ApiType.ShopCart
+        let cart:ApiType.ShopCart
         if (type === 'cart') {
             cart = await Api.patch<ApiType.ShopCart>('/api-shop/cart/', id, {
                 isOpen:0,
@@ -175,7 +178,7 @@ export const MypageAction = {
         return MypageAction.loadBilling(profile)
     },
     loadBilling:async(profile:ApiType.Profile)=>{
-        const res = await Api.list<{total_page:Number, items:ApiType.ShopBilling[]}>('/api-shop/billing/',{
+        const res = await Api.list<{total_page:Number, items:ApiType.ShopBilling<number, ApiType.ShopSubscription>[]}>('/api-shop/billing/',{
             page:1,
             count_per_page:10,
             profile:profile.id
@@ -183,8 +186,10 @@ export const MypageAction = {
         const subs = await Api.list<ApiType.ShopSubscription[]>('/api-shop/subscription/', {
             'pk__in[]':res.items.map(item=>item.subscription)
         })
+        console.log(res)
+        console.log(subs)
         res.items.forEach(billing=> {
-            billing.subscription = subs.filter(sub=>billing.subscription == sub.id)[0]
+            billing.subscription = subs.filter(sub=>billing.subscription.id === sub.id)[0]
         })
         return Promise.resolve({billings:res.items})
     }

--- a/react/src/types/api.types.d.ts
+++ b/react/src/types/api.types.d.ts
@@ -5,19 +5,19 @@ export type Device<A=number> = {
     fcm_token:string
     type:string
     refresh_token:string
-    profile:A
+    profile:A // Profile
 }
 export type Media<A=number,B=number,C=number> = {
     id:number
     file:string
-    boarditem:A
-    shopproduct:B
-    profile:C
+    boarditem:A // BoardItem
+    shopproduct:B // ShopProduct
+    profile:C // Profile
     extra:string
 }
 export type Profile<A=number> = {
     id:number
-    user:A
+    user:A // custom.auth.User
     name:string
     profile_img:string
 }
@@ -25,18 +25,18 @@ export type MonitorUsage<A=number,B=number> = {
     id:number
     percent:number
     dt:string
-    cpu:A
-    memory:B
+    cpu:A // MonitorCpu
+    memory:B // MonitorMemory
 }
 export type MonitorCpu<A=number> = {
     id:number
     name:string
-    server:A
+    server:A // MonitorServer
 }
 export type MonitorMemory<A=number> = {
     id:number
     total:number
-    server:A
+    server:A // MonitorServer
 }
 export type MonitorServer = {
     id:number
@@ -45,22 +45,22 @@ export type MonitorServer = {
 }
 export type ChatMessage<A=number,B=number> = {
     id:number
-    sender:A
+    sender:A // Profile
     content:string
     created:string
-    room:B
+    room:B // ChatRoom
 }
 export type ChatRoom<A=number> = {
     id:number
-    user:A[]
+    user:A[] // Profile[]
 }
 export type BoardComment<A=number,B=number,C=number> = {
     id:number
     content:string
     created:string
-    author:A
-    item:B
-    parent:C
+    author:A // Profile
+    item:B // BoardItem
+    parent:C // BoardComment
 }
 export type BoardItem<A=number,B=number> = {
     id:number
@@ -68,9 +68,9 @@ export type BoardItem<A=number,B=number> = {
     content:string
     created:string
     modified:string
-    author:A
+    author:A // Profile
     valid:boolean
-    group:B
+    group:B // BoardGroup
 }
 export type BoardGroup = {
     id:number
@@ -80,8 +80,8 @@ export type BoardGroup = {
 export type ShopCart<A=number,B=number> = {
     id:number
     isOpen:boolean
-    profile:A
-    product:B[]
+    profile:A // Profile
+    product:B[] // ShopProduct
 }
 export type ShopProduct = {
     id:number
@@ -101,31 +101,31 @@ export type ShopPayment<A=number> = {
     imp_uid:string
     status:string
     vbank:string
-    cart:A
+    cart:A // ShopCart
 }
 export type ShopBilling<A=number,B=number,C=number> = {
     id:number
-    profile:A
+    profile:A // Profile
     created:string
     expired:string
     scheduled:boolean
     imp_uid:string
     merchant_uid:string
-    subscription:B
-    card:C
+    subscription:B // ShopSubscription
+    card:C // ShopCard
 }
 export type ShopCard<A=number> = {
     id:number
     name:string
     customer_uid:string
-    profile:A
+    profile:A // Profile
     buyer_name:string
     buyer_email:string
     buyer_tel:string
 }
 export type TaskWork<A=number> = {
     id:number
-    owner:A
+    owner:A // Profile
     progress:number
     status:string
     body:string
@@ -133,5 +133,5 @@ export type TaskWork<A=number> = {
 export type TaskClient<A=number> = {
     id:number
     channel_name:string
-    work:A
+    work:A // TaskWork
 }

--- a/react/src/types/api.types.d.ts
+++ b/react/src/types/api.types.d.ts
@@ -1,11 +1,12 @@
 import * as custom from './custom.types'
 
-export type Device = {
+export type Device<T=number> = {
     id:number
     fcm_token:string
     type:string
     refresh_token:string
-    profile:number|Profile
+    // profile:number|Profile
+    profile:T
 }
 export type Media = {
     id:number

--- a/react/src/types/api.types.d.ts
+++ b/react/src/types/api.types.d.ts
@@ -1,115 +1,87 @@
 import * as custom from './custom.types'
 
-export type Device<T=number> = {
+export type Device<A=number> = {
     id:number
     fcm_token:string
     type:string
     refresh_token:string
-    // profile:number|Profile
-    profile:T
+    profile:A
 }
-export type Media = {
+export type Media<A=number,B=number,C=number> = {
     id:number
     file:string
-    boarditem:number|BoardItem
-    shopproduct:number|ShopProduct
-    profile:number|Profile
+    boarditem:A
+    shopproduct:B
+    profile:C
     extra:string
 }
-export type Profile = {
+export type Profile<A=number> = {
     id:number
-    user:number|custom.auth.User
+    user:A
     name:string
     profile_img:string
+}
+export type MonitorUsage<A=number,B=number> = {
+    id:number
+    percent:number
+    dt:string
+    cpu:A
+    memory:B
+}
+export type MonitorCpu<A=number> = {
+    id:number
+    name:string
+    server:A
+}
+export type MonitorMemory<A=number> = {
+    id:number
+    total:number
+    server:A
 }
 export type MonitorServer = {
     id:number
     address:string
     keep_day:number
 }
-export type MonitorUsage = {
+export type ChatMessage<A=number,B=number> = {
     id:number
-    percent:number
-    dt:string
-    cpu:number|MonitorCpu
-    memory:number|MonitorMemory
+    sender:A
+    content:string
+    created:string
+    room:B
 }
-export type MonitorMemory = {
+export type ChatRoom<A=number> = {
     id:number
-    total:number
-    server:number|MonitorServer
+    user:A[]
 }
-export type MonitorCpu = {
+export type BoardComment<A=number,B=number,C=number> = {
     id:number
-    name:string
-    server:number|MonitorServer
+    content:string
+    created:string
+    author:A
+    item:B
+    parent:C
 }
-export type BoardItem = {
+export type BoardItem<A=number,B=number> = {
     id:number
     title:string
     content:string
     created:string
     modified:string
-    author:number|Profile
+    author:A
     valid:boolean
-    group:number|BoardGroup
-}
-export type BoardComment = {
-    id:number
-    content:string
-    created:string
-    author:number|Profile
-    item:number|BoardItem
-    parent:number|BoardComment
+    group:B
 }
 export type BoardGroup = {
     id:number
     name:string
     readonly:boolean
 }
-export type TaskClient = {
-    id:number
-    channel_name:string
-    work:number|TaskWork
-}
-export type TaskWork = {
-    id:number
-    owner:number|Profile
-    progress:number
-    status:string
-    body:string
-}
-export type ShopSubscription = {
-    id:number
-    name:string
-    price:number
-    valid:boolean
-}
-export type ShopBilling = {
-    id:number
-    profile:number|Profile
-    created:string
-    expired:string
-    scheduled:boolean
-    imp_uid:string
-    merchant_uid:string
-    subscription:number|ShopSubscription
-    card:number|ShopCard
-}
-export type ShopCart = {
+export type ShopCart<A=number,B=number> = {
     id:number
     isOpen:boolean
-    profile:number|Profile
-    product:number[]|ShopProduct[]
-}
-export type ShopCard = {
-    id:number
-    name:string
-    customer_uid:string
-    profile:number|Profile
-    buyer_name:string
-    buyer_email:string
-    buyer_tel:string
+    profile:A
+    product:B[]
 }
 export type ShopProduct = {
     id:number
@@ -118,21 +90,48 @@ export type ShopProduct = {
     valid:boolean
     content:string
 }
-export type ShopPayment = {
+export type ShopSubscription = {
+    id:number
+    name:string
+    price:number
+    valid:boolean
+}
+export type ShopPayment<A=number> = {
     id:number
     imp_uid:string
     status:string
     vbank:string
-    cart:number|ShopCart
+    cart:A
 }
-export type ChatRoom = {
+export type ShopBilling<A=number,B=number,C=number> = {
     id:number
-    user:number[]|Profile[]
-}
-export type ChatMessage = {
-    id:number
-    sender:number|Profile
-    content:string
+    profile:A
     created:string
-    room:number|ChatRoom
+    expired:string
+    scheduled:boolean
+    imp_uid:string
+    merchant_uid:string
+    subscription:B
+    card:C
+}
+export type ShopCard<A=number> = {
+    id:number
+    name:string
+    customer_uid:string
+    profile:A
+    buyer_name:string
+    buyer_email:string
+    buyer_tel:string
+}
+export type TaskWork<A=number> = {
+    id:number
+    owner:A
+    progress:number
+    status:string
+    body:string
+}
+export type TaskClient<A=number> = {
+    id:number
+    channel_name:string
+    work:A
 }


### PR DESCRIPTION
## Requirements
기존의 유니온 타입(ex `profile:number|Profile` )으로 정의된 부분을 제거하고
프로젝트의 규모가 커질수록 `aaa[0].profile as ApiType.Profile` 와 같은 형태의
사용이 지속되면 작은 부분의 변화에도 관련된 수많은 데이터를 추적해야 할 수고가 늘어나기에 
이러한 문제를 해결 하고자 함.

## Solutions
1. 제네릭을 이용한 `expand` 함수의 `return`타입 정의
2. type 선언 시 기존의 유니온 타입으로 정의한 부분을 제네릭으로 받아 대체

## TODO
- [x]  staruml-django 익스텐션 파일을 바뀐 rule에 맞도록 수정

## Update
1.  *.action.tsx 파일에 제네릭 타입 적용
